### PR TITLE
Implemented smart scaling scaler flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,48 +8,54 @@ The core of this script is a powerful 2-pass VP9 encoding routine wrapped around
 
 ## Features
 
- * **Target Size Compression:** Calculate the exact video bitrate needed to hit a specified file size (e.g., --size 50 MiB).
- * **WebM (VP9/Opus):** Optimized for creating modern, efficient WebM files.
- * **Trimming & Manipulation:** Supports trimming (--start, --end), scaling (--scale), speed adjustment (--speed), and custom FFmpeg filter insertion.
- * **Hardsub Support:** Easily burn in subtitles from the input file, automatically handling sync even when trimming mid-video.
- * **Web Compatibility Mode:** One-flag fix (`--target-web`) to force 8-bit color and Profile 0, ensuring videos play on all browsers and mobile devices.
- * **Prototype Mode:** Quickly test cuts and filters using a fast single-pass CRF encode (`--proto`), with adjustable quality/speed trade-off.
- * **Command Inspection:** Use `--print` to output the exact FFmpeg commands for debugging or use in shell scripts.
- * **Robustness:** Uses the -nostdin flag to prevent accidental keyboard input from interrupting long-running jobs.
- * **Scene Processing:** Includes scene_runner.py for batch processing scenes from tools like [PysceneDetect](https://github.com/Breakthrough/PySceneDetect).
+* **Target Size Compression:** Calculate the exact video bitrate needed to hit a specified file size (e.g., --size 50 MiB).
+* **WebM (VP9/Opus):** Optimized for creating modern, efficient WebM files.
+* **Smart Scaling:** Automatically detects integer-ratio scaling (e.g., 4K -> 1080p) and uses `neighbor` for pixel-perfect sharpness, or falls back to `bicubic` for other ratios to prevent aliasing.
+* **Trimming & Manipulation:** Supports trimming (--start, --end), scaling (--scale), speed adjustment (--speed), and custom FFmpeg filter insertion.
+* **Hardsub Support:** Easily burn in subtitles from the input file, automatically handling sync even when trimming mid-video.
+* **Web Compatibility Mode:** One-flag fix (`--target-web`) to force 8-bit color and Profile 0, ensuring videos play on all browsers and mobile devices.
+* **Prototype Mode:** Quickly test cuts and filters using a fast single-pass CRF encode (`--proto`), with adjustable quality/speed trade-off.
+* **Command Inspection:** Use `--print` to output the exact FFmpeg commands for debugging or use in shell scripts.
+* **Robustness:** Uses the -nostdin flag to prevent accidental keyboard input from interrupting long-running jobs.
+* **Scene Processing:** Includes scene_runner.py for batch processing scenes from tools like [PysceneDetect](https://github.com/Breakthrough/PySceneDetect).
 
 ## Installation and Setup
 
 ### Prerequisites
-You must have FFmpeg and FFprobe installed and accessible in your system's `$PATH` (on Windows: `%PATH%`).
- * Windows/Linux/macOS: Ensure you can run `ffmpeg -version` and `ffprobe -version` successfully from your terminal.
+
+You must have FFmpeg and FFprobe installed and accessible in your system's `$PATH` (on Windows: `%PATH%`). Windows/Linux/macOS: Ensure you can run `ffmpeg -version` and `ffprobe -version` successfully from your terminal.
 
 ### Option 1: Editable Installation (Recommended for Development)
+
 This method uses your pyproject.toml file to install the package in an editable state. This allows you to run the script using the clean command py100mbify from any directory on your system.
- * Navigate to the root directory of this project (where pyproject.toml is located).
- * Install the project using pip or uv:
-   ```bash
-   # Use pip (standard method)
-   pip install -e .
 
-   # OR use uv (if you prefer this faster tool)
-   uv pip install -e .
-   ```
-   The -e flag (editable) means any changes you make to the source files (`__init__.py`) are reflected immediately without reinstalling.
- * Run the tool from anywhere:
-   ```bash
-   py100mbify input.mp4 output.webm --size 50
+* Navigate to the root directory of this project (where pyproject.toml is located).
+* Install the project using pip or uv:
+  ```bash
+  # Use pip (standard method)
+  pip install -e .
 
-   ```
+  # OR use uv (if you prefer this faster tool)
+  uv pip install -e .
+  ```
+* The `-e` flag (editable) means any changes you make to the source files (`__init__.py`) are reflected immediately without reinstalling.
+* Run the tool from anywhere:
+  ```bash
+  py100mbify input.mp4 output.webm --size 50
+  ```
 
 ### Option 2: Direct Script Execution (No Global Install)
+
 If you prefer not to install the package, you can run the main script directly using Python's module execution (-m).
- * Navigate to the directory containing the py100mbify directory.
- * Run the script using the module name:
-   ```
-   python -m py100mbify input.mp4 output.webm --size 50
-   ```
-  Note: If you run this from inside the py100mbify directory, you should use `python __init__.py ...` instead.
+
+* Navigate to the directory containing the py100mbify directory.
+
+* Run the script using the module name:
+  ```
+  python -m py100mbify input.mp4 output.webm --size 50
+  ```
+
+* Note: If you run this from inside the py100mbify directory, you should use `python __init__.py ...` instead.
 
 ## Usage
 
@@ -69,6 +75,7 @@ py100mbify input.mp4 output.webm --size 100
 | --size | Target output size in MiB. (Default: 100) | --size 50 |
 | --start / --end | Trimming start and end times (seconds or HH:MM:SS.ms). | --start 10 --end 30.5 |
 | --scale | Resizes the smallest dimension (e.g., 720 for 720p equivalent). | --scale 1080 |
+| --scaler | **(New)** Manual override for scaling algorithm (neighbor, bicubic, lanczos). | --scaler neighbor |
 | --mute | Removes the audio track. | --mute |
 | --hard-sub | Burn subtitles from the input file. Handles sync automatically. | --hard-sub |
 | --target-web | Force 8-bit color (Profile 0) for browser compatibility. | --target-web |

--- a/README.md
+++ b/README.md
@@ -11,26 +11,27 @@ The core of this script is a powerful 2-pass VP9 encoding routine wrapped around
 * **Target Size Compression:** Calculate the exact video bitrate needed to hit a specified file size (e.g., --size 50 MiB).
 * **WebM (VP9/Opus):** Optimized for creating modern, efficient WebM files.
 * **Smart Scaling:** Automatically detects integer-ratio scaling (e.g., 4K -> 1080p) and uses `neighbor` for pixel-perfect sharpness, or falls back to `bicubic` for other ratios to prevent aliasing.
-* **Trimming & Manipulation:** Supports trimming (--start, --end), scaling (--scale), speed adjustment (--speed), and custom FFmpeg filter insertion.
+* **Trimming & Manipulation:** Supports trimming (`--start`, `--end`), scaling (`--scale`), speed adjustment (`--speed`), and custom FFmpeg filter insertion.
 * **Hardsub Support:** Easily burn in subtitles from the input file, automatically handling sync even when trimming mid-video.
 * **Web Compatibility Mode:** One-flag fix (`--target-web`) to force 8-bit color and Profile 0, ensuring videos play on all browsers and mobile devices.
 * **Prototype Mode:** Quickly test cuts and filters using a fast single-pass CRF encode (`--proto`), with adjustable quality/speed trade-off.
 * **Command Inspection:** Use `--print` to output the exact FFmpeg commands for debugging or use in shell scripts.
 * **Robustness:** Uses the -nostdin flag to prevent accidental keyboard input from interrupting long-running jobs.
-* **Scene Processing:** Includes scene_runner.py for batch processing scenes from tools like [PysceneDetect](https://github.com/Breakthrough/PySceneDetect).
+* **Scene Processing:** Includes `scene_runner.py` for batch processing scenes from tools like [PysceneDetect](https://github.com/Breakthrough/PySceneDetect).
 
 ## Installation and Setup
 
 ### Prerequisites
 
-You must have FFmpeg and FFprobe installed and accessible in your system's `$PATH` (on Windows: `%PATH%`). Windows/Linux/macOS: Ensure you can run `ffmpeg -version` and `ffprobe -version` successfully from your terminal.
+You must have FFmpeg and FFprobe installed and accessible in your system's `$PATH` (on Windows: `%PATH%`). Ensure you can run `ffmpeg -version` and `ffprobe -version` successfully from your terminal.
 
 ### Option 1: Editable Installation (Recommended for Development)
 
-This method uses your pyproject.toml file to install the package in an editable state. This allows you to run the script using the clean command py100mbify from any directory on your system.
+This method uses the `pyproject.toml` to install the package in an editable state. This allows you to run the script using the clean command py100mbify from any directory on your system.
 
-* Navigate to the root directory of this project (where pyproject.toml is located).
-* Install the project using pip or uv:
+* Navigate to the root directory of this project (where `pyproject.toml` is located).
+
+* Install the project using `pip` or `uv`:
   ```bash
   # Use pip (standard method)
   pip install -e .
@@ -38,7 +39,9 @@ This method uses your pyproject.toml file to install the package in an editable 
   # OR use uv (if you prefer this faster tool)
   uv pip install -e .
   ```
+
 * The `-e` flag (editable) means any changes you make to the source files (`__init__.py`) are reflected immediately without reinstalling.
+
 * Run the tool from anywhere:
   ```bash
   py100mbify input.mp4 output.webm --size 50
@@ -46,7 +49,7 @@ This method uses your pyproject.toml file to install the package in an editable 
 
 ### Option 2: Direct Script Execution (No Global Install)
 
-If you prefer not to install the package, you can run the main script directly using Python's module execution (-m).
+If you prefer not to install the package, you can run the main script directly using Python's module execution (`-m`).
 
 * Navigate to the directory containing the py100mbify directory.
 
@@ -65,7 +68,6 @@ The basic usage requires an input file, an output file, and the target size.
 
 ```bash
 py100mbify input.mp4 output.webm --size 100
-
 ```
 
 | Argument | Description | Example |
@@ -75,7 +77,7 @@ py100mbify input.mp4 output.webm --size 100
 | --size | Target output size in MiB. (Default: 100) | --size 50 |
 | --start / --end | Trimming start and end times (seconds or HH:MM:SS.ms). | --start 10 --end 30.5 |
 | --scale | Resizes the smallest dimension (e.g., 720 for 720p equivalent). | --scale 1080 |
-| --scaler | **(New)** Manual override for scaling algorithm (neighbor, bicubic, lanczos). | --scaler neighbor |
+| --scaler | Manual override for scaling algorithm (neighbor, bicubic, lanczos). | --scaler neighbor |
 | --mute | Removes the audio track. | --mute |
 | --hard-sub | Burn subtitles from the input file. Handles sync automatically. | --hard-sub |
 | --target-web | Force 8-bit color (Profile 0) for browser compatibility. | --target-web |
@@ -84,7 +86,7 @@ py100mbify input.mp4 output.webm --size 100
 
 ### Scene Batch Processing
 
-Use the dedicated scene_runner.py script to process a video segmented by a CSV file (e.g., from scenedetect).
+Use the dedicated `scene_runner.py` script to process a video segmented by a CSV file (e.g., from scenedetect).
 
 ```bash
 python scene_runner.py \
@@ -92,7 +94,6 @@ python scene_runner.py \
     /path/to/scenes.csv \
     --output-dir ./scenes_out \
     --size 20
-
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,10 @@ classifiers = [
 py100mbify = "py100mbify:main"
 
 [build-system]
-requires = ["uv_build>=0.8.17,<0.9.0"]
-build-backend = "uv_build"
+# Switch to setuptools for a pure-Python build chain.
+# This avoids needing Rust/maturin on lightweight environment.
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages]
 find = {where = ["src"]}

--- a/src/py100mbify/__init__.py
+++ b/src/py100mbify/__init__.py
@@ -175,7 +175,8 @@ def run_ffmpeg_pass(pass_number, input_file, output_file, effective_duration_sec
 
     # Use -t (duration) instead of -to (end time) for accurate clipping when combined with -ss.
     if clip_duration_seconds:
-        cmd.extend(['-t', f'{clip_duration_seconds:.3f}'])
+        safe_duration = max(0, clip_duration_seconds - 0.001)
+        cmd.extend(['-t', f'{safe_duration:.3f}'])
 
     cmd.extend(['-i', input_file])
 

--- a/src/py100mbify/__init__.py
+++ b/src/py100mbify/__init__.py
@@ -66,6 +66,27 @@ def escape_ffmpeg_path(path):
     path = path.replace("'", "'\\\\''")
     return path
 
+def get_video_filter(src_h, target_h, manual_scaler=None):
+    """
+    Determines the appropriate scaling filter string for FFmpeg.
+
+    Logic:
+    1. If a manual scaler is provided, use it.
+    2. If source height is an integer multiple of target height (e.g. 2160 -> 1080),
+       use 'neighbor' for pixel-perfect sharpness.
+    3. Otherwise, use 'bicubic' to prevent aliasing on non-integer scales.
+    """
+    if manual_scaler:
+        flags = manual_scaler
+    else:
+        # Smart detection logic
+        if src_h and target_h and src_h > 0 and (src_h % target_h == 0):
+            flags = 'neighbor'
+        else:
+            flags = 'bicubic'
+
+    return f'scale=-2:{target_h}:flags={flags}'
+
 def get_video_info(input_file):
     """
     Use ffprobe to get the video's duration, resolution, FPS, and audio stream information.
@@ -118,7 +139,7 @@ def get_video_info(input_file):
 
 def run_ffmpeg_pass(pass_number, input_file, output_file, effective_duration_seconds, clip_duration_seconds,
                     target_video_bitrate_kbps, audio_bitrate, mute, speed, start, end,
-                    fps, scale, cpu_priority, prepend_filters, append_filters, pass_log_file,
+                    fps, scale_filter, cpu_priority, prepend_filters, append_filters, pass_log_file,
                     threads, quality, rotate, keep_metadata, hard_sub=False, target_web=False, proto=False,
                     print_mode=False):
     """
@@ -199,9 +220,9 @@ def run_ffmpeg_pass(pass_number, input_file, output_file, effective_duration_sec
         # Applies speed filter before scaling/cropping/etc.
         video_filters.append(f'setpts={1/speed}*PTS')
 
-    # 4. Scale
-    if scale:
-        video_filters.append(f'scale=-2:{scale}')
+    # 4. Scale (Now uses the pre-calculated filter string)
+    if scale_filter:
+        video_filters.append(scale_filter)
 
     # 5. FPS
     if fps:
@@ -369,7 +390,7 @@ def calculate_bitrates(size, effective_duration_seconds, audio_bitrate, is_audio
 
 def compress_video(input_file, output_file=None, size=DEFAULT_TARGET_SIZE_MIB,
                     audio_bitrate=DEFAULT_AUDIO_BITRATE_KBPS, mute=False, speed=1.0,
-                    start=None, end=None, fps=None, scale=None, cpu_priority=None,
+                    start=None, end=None, fps=None, scale=None, scaler=None, cpu_priority=None,
                     prepend_filters=None, append_filters=None, rotate=None, keep_metadata=False,
                     hard_sub=False, target_web=False, info_detail=False, proto=False,
                     print_mode=False):
@@ -445,6 +466,11 @@ def compress_video(input_file, output_file=None, size=DEFAULT_TARGET_SIZE_MIB,
         log_base_name = os.path.splitext(os.path.basename(output_file))[0]
         pass_log_file = os.path.join(os.path.dirname(output_file) or os.getcwd(), f"{log_base_name}_passlog")
 
+        # --- Logic: Smart Scaling Filter Construction ---
+        scale_filter = None
+        if scale:
+            scale_filter = get_video_filter(video_height, scale, scaler)
+
         # --- Initial Conversion Summary ---
         if info_detail:
             print("--- WebM Conversion Script Summary ---")
@@ -475,7 +501,9 @@ def compress_video(input_file, output_file=None, size=DEFAULT_TARGET_SIZE_MIB,
             print(f"Final Output Duration (Time-Scaled): {effective_duration_seconds:.2f} seconds")
 
             if scale:
-                 print(f"Target Scale (min dimension): {scale}p")
+                 # Extract method for display
+                 method = scale_filter.split('flags=')[-1] if 'flags=' in scale_filter else 'unknown'
+                 print(f"Target Scale: {scale}p (Method: {method})")
             if fps:
                  print(f"Target FPS: {fps}")
             if rotate is not None:
@@ -515,19 +543,19 @@ def compress_video(input_file, output_file=None, size=DEFAULT_TARGET_SIZE_MIB,
         if not proto:
             # Pass 1 (only for 2-pass mode)
             run_ffmpeg_pass(1, input_file, os.devnull, effective_duration_seconds, clip_duration_seconds, target_video_bitrate_kbps,
-                            audio_bitrate, mute, speed, start, end, fps, scale, cpu_priority,
+                            audio_bitrate, mute, speed, start, end, fps, scale_filter, cpu_priority,
                             prepend_filters, append_filters, pass_log_file, threads, quality, rotate, keep_metadata,
                             hard_sub=hard_sub, target_web=target_web, proto=proto, print_mode=print_mode)
 
             # Pass 2
             run_ffmpeg_pass(2, input_file, output_file, effective_duration_seconds, clip_duration_seconds, target_video_bitrate_kbps,
-                            audio_bitrate, mute, speed, start, end, fps, scale, cpu_priority,
+                            audio_bitrate, mute, speed, start, end, fps, scale_filter, cpu_priority,
                             prepend_filters, append_filters, pass_log_file, threads, quality, rotate, keep_metadata,
                             hard_sub=hard_sub, target_web=target_web, proto=proto, print_mode=print_mode)
         else:
             # PROTO mode (single-pass)
             run_ffmpeg_pass(2, input_file, output_file, effective_duration_seconds, clip_duration_seconds, target_video_bitrate_kbps,
-                            audio_bitrate, mute, speed, start, end, fps, scale, cpu_priority,
+                            audio_bitrate, mute, speed, start, end, fps, scale_filter, cpu_priority,
                             prepend_filters, append_filters, pass_log_file, threads, quality, rotate, keep_metadata,
                             hard_sub=hard_sub, target_web=target_web, proto=proto, print_mode=print_mode)
 
@@ -593,6 +621,8 @@ def main():
     parser.add_argument('--fps', type=int, help='Set a target frame rate (e.g., 30).')
     parser.add_argument('--scale', type=int,
                         help='Target size for the video\'s smallest dimension (e.g., 720 for 720p equivalent). The other dimension will be calculated to maintain aspect ratio.')
+    parser.add_argument('--scaler', choices=['neighbor', 'bicubic', 'lanczos'],
+                        help='Manual scaling algorithm override. If not set, smart-selects "neighbor" for integer scale and "bicubic" otherwise.')
     parser.add_argument('--rotate', type=float,
                         help='Rotate the video by the specified number of degrees. Positive values rotate clockwise, negative values rotate counter-clockwise (to the left).')
     parser.add_argument('--keep-metadata', action='store_true',


### PR DESCRIPTION
By default it is auto-detected: apply integer video filter (`neighbor`) ONLY if the target dimension is integer, otherwise default (`bicubic`). This feature can be overrided using `--scaler` option. Available value are: `['neighbor', 'bicubic', 'lanczos']`.

You can now run `py100mbify input.mp4 --scale 720 --scaler neighbor` to force it, or just `py100mbify input.mp4 --scale 720` to let the auto-detection work.

Additional changes included in this PR:
* Dropped `uv_build`
* Fixed timing precision by subtract it by 0.001.
